### PR TITLE
eslint circle ci導入後の修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-register": "^6.18.0",
     "babel-runtime": "^6.20.0",
     "doc-ready": "^1.0.4",
+    "es6-promise": "^4.0.5",
     "jszip": "^3.1.3",
     "jszip-utils": "^0.0.2",
     "material-ui": "^0.16.5",

--- a/src/reducers/viewer.js
+++ b/src/reducers/viewer.js
@@ -44,7 +44,7 @@ const viewer = (state = initialAppState, action) => {
         ...state,
         open: action.open,
       };
-    case actionTypes.ON_DROP_FILES:
+    case actionTypes.ON_DROP_FILES: {
       const imtes = action.files.map((file, index) => ({
         id: state.items.length + 1 + index,
         file: createObjectURL(file)
@@ -56,6 +56,7 @@ const viewer = (state = initialAppState, action) => {
           ...imtes
         ]
       };
+    }
     default:
       return state;
   }

--- a/src/sagas/index.js
+++ b/src/sagas/index.js
@@ -3,6 +3,7 @@ import { call, put, takeEvery } from 'redux-saga/effects'
 import * as actionTypes from 'utils/actionTypes';
 import JSZip from 'jszip';
 import path from 'path';
+import { Promise } from 'es6-promise';
 
 const rejectPtn = /.*__MACOSX.*/;
 const supportExtPtn = /^\.(jpg|jpeg|png|gif)$/;
@@ -36,7 +37,7 @@ function* handleUnzip(action) {
 
     yield put({type: actionTypes.ON_DROP_FILES, files: unzipFiles});
   } catch (e) {
-    console.log(e);
+    // console.log(e);
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,6 +2082,10 @@ es6-map@^0.1.3:
     es6-symbol "~3.1.0"
     event-emitter "~0.3.4"
 
+es6-promise@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.0.5.tgz#7882f30adde5b240ccfa7f7d78c548330951ae42"
+
 es6-promise@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"


### PR DESCRIPTION
### 概要
circle ci 導入時に eslintのテストをかけるようにした。
lint errorが出てるので治す

### 変更点
- es6-promise プラグイン追加
- lint fix

### 関連 issue


### 参考
